### PR TITLE
Add support for reviewing specific files or directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Create a configuration file called `revus.toml` with the following parameters:
 
 ## Usage
 
+To view the help information for Revus, run:
+```bash
+revus --help
+```
 To review changes with Revus, first add modified files to staging:
 ```bash
 git add <file_name>
@@ -34,6 +38,10 @@ git add .
 Then, run the application in the project folder:
 ```bash
 revus
+```
+To review changes in a specific file or directory, use the -p option:
+```bash
+revus -p <path_to_file_or_directory>
 ```
 
 **Important**: Revus reviews each file individually, simplifying context management.

--- a/revus/app/cli.py
+++ b/revus/app/cli.py
@@ -1,5 +1,6 @@
 # app/cli.py
 
+import argparse
 import xml.etree.ElementTree as ET
 from .logger import log_warning, console
 
@@ -56,3 +57,20 @@ def format_review_output(review):
     output.append(review_summary)
 
     return "\n".join(output)
+
+
+def parse_cli_args() -> argparse.Namespace:
+    """Parse CLI arguments to define a file or directory for automated review."""
+    parser = argparse.ArgumentParser(
+        description="Automated PR Review Application using LLM",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--path",
+        type=str,
+        help="Path to a file or directory for review",
+        default=None,
+    )
+
+    return parser.parse_args()

--- a/revus/app/git_operations.py
+++ b/revus/app/git_operations.py
@@ -19,14 +19,10 @@ def get_file_changes():
     args = parse_cli_args()
     requested_path = args.path
 
-    if requested_path:
-        staged_files = [
-            file
-            for file in staged_files
-            if os.path.exists(file) and file.startswith(requested_path)
-        ]
-    else:
-        staged_files = [file for file in staged_files if os.path.exists(file)]
+    staged_files = [
+        file for file in staged_files
+        if os.path.exists(file) and (not requested_path or file.startswith(requested_path))
+    ]
 
     file_types = get_config("file_types", [".py"])
     exclude_paths = get_config("exclude_paths", [])

--- a/revus/app/git_operations.py
+++ b/revus/app/git_operations.py
@@ -5,16 +5,28 @@ import sys
 from git import Repo, InvalidGitRepositoryError, GitCommandError
 from .config import get_config
 from .logger import log_error
+from .cli import parse_cli_args
 
 
 def get_file_changes():
     try:
         repo = Repo(".")
         staged_files = {item.a_path for item in repo.index.diff("HEAD", staged=True)}
-        staged_files = [file for file in staged_files if os.path.exists(file)]
     except (InvalidGitRepositoryError, GitCommandError) as e:
         log_error(f"Error working with Git repository: {e}")
         return {}
+
+    args = parse_cli_args()
+    requested_path = args.path
+
+    if requested_path:
+        staged_files = [
+            file
+            for file in staged_files
+            if os.path.exists(file) and file.startswith(requested_path)
+        ]
+    else:
+        staged_files = [file for file in staged_files if os.path.exists(file)]
 
     file_types = get_config("file_types", [".py"])
     exclude_paths = get_config("exclude_paths", [])


### PR DESCRIPTION
This pull request introduces a new feature that allows users to specify a file or directory for review using the -p or --path option in the CLI. This enhancement improves the usability of the tool by enabling targeted reviews of specific changes.

Key Changes:
1. Added a -p / --path CLI option to specify a file or directory for review.
2. Updated logic to filter staged files based on the provided path.
3. Improved documentation in the Usage section to reflect the new functionality.

How It Works:
If the --path argument is provided, the tool will only review staged files that are within the specified path (file or directory).
If no path is provided, the tool defaults to reviewing all staged files.